### PR TITLE
updated for maistra-0.10

### DIFF
--- a/ABTesting.md
+++ b/ABTesting.md
@@ -60,7 +60,7 @@ Wait a few minutes until the service graph shows grey lines (0 requests/sec) eve
 Let's now test the app again by pumping some load
 
 ```
-export URL=$(kubectl get route istio-ingressgateway -n istio-system -o yaml -o jsonpath={.spec.host})
+export URL=$(kubectl get virtualservice bookinfo -o yaml -o jsonpath={.spec.hosts[0]})
 ```
 
 Let us send 100 requests

--- a/InstallingIstioOnOpenShift.md
+++ b/InstallingIstioOnOpenShift.md
@@ -1,10 +1,10 @@
 # Deploying Istio on OpenShift
 
-Here we will learn the administrative steps to deploy Istio on OpenShift and set up the Istio cluster for running the examples to follow in a multi user environment. The instructions listed here are based on the official documentation [here](https://docs.openshift.com/container-platform/3.10/servicemesh-install/servicemesh-install.html).
+Here we will learn the administrative steps to deploy Istio on OpenShift and set up the Istio cluster for running the examples to follow in a multi user environment. The instructions listed here are based on the official documentation [here](https://docs.openshift.com/container-platform/3.11/servicemesh-install/servicemesh-install.html).
 
 >**Note** Istio on OpenShift is still Tech Preview. So, these labs are to learn how things are shaping up. Technology Preview releases are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete, and Red Hat does NOT recommend using them for production. 
 
-These steps have been tested for `OCP 3.11.16`.
+These steps have been tested for `openshift v3.11.88`.
 
 ## Prerequisites
 * A Running OpenShift Cluster that is deployed either using `ovs-subnet` or `ovs-networkpolicy` plugins
@@ -100,208 +100,184 @@ ansible nodes -i hostnames.txt -m shell -a "echo 'vm.max_map_count = 262144' > /
 ansible nodes -i hostnames.txt -m shell -a "sysctl vm.max_map_count=262144"
 ```
 
+**Note:** If you restart the nodes, the setting `sysctl vm.max_map_count=262144` goes away. You may want to check and run the command again. 
+
 ## Installing Service Mesh
 
-Installing Istio on OpenShift involves creating a custom resource definition file, then installing mesh an using operator to create and manage the custom resource. 
+Istio installation is handled by an operator on OpenShift. Istio operator runs as a pod and it watches custom resource (CR) of kind `controlplane`. If a custom resource of kind `controlplane` is created, the operator follows the configurated provided in that CR and creates a control plane accordingly.
 
+### Installing Istio Operator
 
-### Create the CRD file
+As a cluster administrator run the following
 
-Create a file with name `istio_installation.yaml` with the following contents. This should be sufficient for the purpose of our workshop. [OpenShift Istio documentation](https://docs.openshift.com/container-platform/3.10/servicemesh-install/servicemesh-install.html#creating-custom-resource) has some additional features such as Fabric8 launcher with Istio. 
-
-This configuration instructs the operator 
-* to install istio on an OCP cluster (`deployment_type: openshift`)
-* the version of istio is tech preview
-* install jaeger 1.8.1 for tracing and to use elasticsearch with `1Gi` memory
-* install kiali 0.10.1 for observability and the credentials to log onto kiali are `admin/admin`. You may want to change these to values of your choice.
-
-```
-# cat istio-installation.yaml 
-apiVersion: "istio.openshift.com/v1alpha1"
-kind: "Installation"
-metadata:
-  name: "istio-installation"
-spec:
-  deployment_type: openshift
-  istio:
-    authentication: true 
-    community: false
-    prefix: openshift-istio-tech-preview/
-    version: 0.5.0
-  jaeger:
-    prefix: distributed-tracing-tech-preview/
-    version: 1.8.1
-    elasticsearch_memory: 1Gi
-  kiali:
-    username: admin    
-    password: admin 
-    prefix: openshift-istio-tech-preview/
-    version: 0.10.1
-```
-This file is also available [here](./istio_installation.yaml), if you want to directly use it.
-
-
-### Start Installation
-
-Create a new project with name `istio-operator` and invoke the operator template by passing your own value for `OPENSHIFT_ISTIO_MASTER_PUBLIC_URL`, which should be the master's public URL. 
-
-> **Remember** to edit the Master URL value before you run these commands
+* Create two projects to run operator and the other one for istio control plane
 
 ```
 oc new-project istio-operator
-oc new-app -f https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-0.5/istio/istio_product_operator_template.yaml --param OPENSHIFT_ISTIO_MASTER_PUBLIC_URL=master.devday.ocpcloud.com --param OPENSHIFT_RELEASE=v3.11.16
+oc new-project istio-system
 ```
 
-This will start an istio-operator pod that starts the installation. 
+Review the template [https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/servicemesh-operator.yaml](https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/servicemesh-operator.yaml)
+
+This template adds
+* Custom Resource Definitions for `installation` and `controlplane`
+* Adds a cluster role, and service account for `istio-operator` and creates a role-binding
+* Creates a deployment for `istio-operator`. This deployment results in running an `istio-operator` pod that watches the CRs for the above CRDs.
+
+Apply this template to create custom resource definitions and to run the operator.
+
+```
+# oc apply -n istio-operator -f https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/servicemesh-operator.yaml
+
+
+customresourcedefinition.apiextensions.k8s.io/installations.istio.openshift.com created
+customresourcedefinition.apiextensions.k8s.io/controlplanes.istio.openshift.com created
+clusterrole.rbac.authorization.k8s.io/istio-operator created
+serviceaccount/istio-operator created
+clusterrolebinding.rbac.authorization.k8s.io/istio-operator-account-istio-operator-cluster-role-binding created
+deployment.apps/istio-operator created
+```
+
+Verify that the operator is running
 
 ```
 # oc get po -n istio-operator
 NAME                              READY     STATUS    RESTARTS   AGE
-istio-operator-7b4985d56b-d4r5l   1/1       Running   0          22h
+istio-operator-79c5b4d68f-gvglw   1/1       Running   0          1h
 ```
 
-If you check the logs by running `oc logs istio-operator-7b4985d56b-d4r5l` it will be waiting for the CRD.
-
-Now create the CRD by running. 
+Also verify the CRDS created
 
 ```
-oc create -f istio-installation.yaml 
+# oc get crd installations.istio.openshift.com
+NAME                                CREATED AT
+installations.istio.openshift.com   2019-04-25T23:25:51Z
+
+# oc get crd controlplanes.istio.openshift.com
+NAME                                CREATED AT
+controlplanes.istio.openshift.com   2019-04-25T23:25:51Z
 ```
 
-Watch the logs for istio-operator pod and you will notice the installation proceeding as follows
+So if you create a custom resource of kind controlplane, the operator is now ready to act on it.
+
+
+### Create Custom Resource for Istio Installation
+
+A basic istio control plane installation is provided by the custom resource. Review this custom resource [https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/examples/istio_v1alpha3_controlplane_cr_basic.yaml](https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/examples/istio_v1alpha3_controlplane_cr_basic.yaml)
+
+Note the kind is `ControlPlane` (the CRD that was created earlier) and the CR is named `basic-install`
 
 ```
-# oc logs -f istio-operator-7b4985d56b-d4r5l -n istio-operator
-time="2018-10-17T15:29:37Z" level=info msg="Go Version: go1.9.4"
-time="2018-10-17T15:29:37Z" level=info msg="Go OS/Arch: linux/amd64"
-time="2018-10-17T15:29:37Z" level=info msg="operator-sdk Version: 0.0.5+git"
-time="2018-10-17T15:29:37Z" level=info msg="Metrics service istio-operator created"
-time="2018-10-17T15:29:37Z" level=info msg="Watching resource istio.openshift.com/v1alpha1, kind Installation, namespace istio-operator, resyncPeriod 0"
-time="2018-10-17T15:29:38Z" level=info msg="Installing istio for Installation istio-installation"
+kind: ControlPlane
+metadata:
+  name: basic-install
 ```
+Notice that the CR provides configurations for various istio control plane components installed by the operator.
 
-Watch the pods in the `istio-system` project and you will notice the following. The number of pods may vary based on the number of nodes you have. Make sure the pods are in `Running` status and the istio-installer pod in `Completed` status.
+We will make a small change to this CR so let us first download this CR 
 
 ```
-NAME                                          READY     STATUS      RESTARTS   AGE
-elasticsearch-0                               1/1       Running     0          2m
-grafana-6d5c5477-k7wrh                        1/1       Running     0          2m
-istio-citadel-6f9c778bb6-q9tg9                1/1       Running     0          3m
-istio-egressgateway-957857444-2g84h           1/1       Running     0          3m
-istio-galley-c47f5dffc-dm27s                  1/1       Running     0          3m
-istio-ingressgateway-7db86747b7-s2dv9         1/1       Running     0          3m
-istio-pilot-5646d7786b-rh54p                  2/2       Running     0          3m
-istio-policy-7d694596c6-pfdzt                 2/2       Running     0          3m
-istio-sidecar-injector-57466d9bb-4cjrs        1/1       Running     0          3m
-istio-statsd-prom-bridge-7f44bb5ddb-6vx7n     1/1       Running     0          3m
-istio-telemetry-7cf7b4b77c-p8m2k              2/2       Running     0          3m
-jaeger-agent-5mswn                            1/1       Running     0          2m
-jaeger-collector-9c9f8bc66-j7kjv              1/1       Running     0          2m
-jaeger-query-fdc6dcd74-99pnx                  1/1       Running     0          2m
-openshift-ansible-istio-installer-job-f8n9g   0/1       Completed   0          7m
-prometheus-84bd4b9796-2vcpc                   1/1       Running     0          3m
-kiali-76b6f689f6-ghj74                        1/1       Running     0          3m
+wget  -O istio-installation.yaml  https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/examples/istio_v1alpha3_controlplane_cr_basic.yaml
 ```
 
+and make a change to enable automatic Istio openshift route creation by changing `ior_enabled` to `true`. This change will start an ior operator that automatically creates a new openshift route for each application you deploy with a specific host so that we have an ingress for our application. If you don't understand this, it's OK. We will discuss more on this later. Run the following command to make the above change to the CR. 
+
+```
+sed -ibak -e "s/ior_enabled: false/ior_enabled: true/" istio-installation.yaml
+```
+
+You can `cat istio-installation.yaml` to verify the change is effective.
+
+
+Create the CR by running
+
+```
+# oc create -f istio-installation.yaml 
+
+controlplane.istio.openshift.com/basic-install created
+```
+Once the CR is created, operator starts installing the istio control plane components. If you watch `istio-system` project running `watch oc get po -n istio-system` eventually you will see the following pods running
+
+```
+watch oc get po -n istio-system
+
+NAME                                      READY     STATUS    RESTARTS   AGE
+elasticsearch-0                           1/1       Running   0          2h
+grafana-6c5dfdf5bd-pphkp                  1/1       Running   0          2h
+ior-69cbb8b7f5-ch6v6                      1/1       Running   0          8m
+istio-citadel-66cf447cbd-9vzlw            1/1       Running   0          2h
+istio-egressgateway-69b65dddf5-mpkbd      1/1       Running   0          2h
+istio-galley-5dbd58568d-g7bkl       	  1/1       Running   0          2h
+istio-ingressgateway-b688c9d9b-st44c      1/1       Running   0          2h
+istio-pilot-79668d4bf6-ppp5n        	  2/2       Running   0          2h
+istio-policy-5f45fcf95f-zn72c             2/2       Running   0          2h
+istio-sidecar-injector-7c44bcbbcd-rshvg   1/1       Running   0          2h
+istio-telemetry-7fcd854d6b-2q7wd          2/2       Running   0          2h
+jaeger-agent-cvgk9                        1/1       Running   0          2h
+jaeger-agent-kjhpb                        1/1       Running   0          2h
+jaeger-agent-kwfxh                        1/1       Running   0          2h
+jaeger-agent-vdv92                        1/1       Running   0          2h
+jaeger-agent-zw7hm                        1/1       Running   0          2h
+jaeger-collector-576b66f88c-qrzrt         1/1       Running   2          2h
+jaeger-query-7549b87c55-cfvfv             1/1       Running   2          2h
+kiali-7475849854-cfxsq                    1/1       Running   0          2h
+prometheus-5dfcf8dcf9-l9xgp               1/1       Running   0          2h
+```
 
 ### Cleanup
 
-**If you need to uninstall Istio** from the OpenShift cluster, the following can be done:
-
-* delete the istio-operator template
-* delete the CRDs `installation` and `istio-installation` and all istio related CRDs created
-* delete cluster roles and cluster rolebindings created for istio
-* delete mutating and validaing webhooks created for istio
-* delete the two projects `istio-operator` and `istio-system`
+To **uninstall Istio Control Plane**, we just need to delete the custom resource and the operator will handle the clean up.
 
 ```
-oc process -f https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-0.5/istio/istio_product_operator_template.yaml | oc delete -f -
-oc delete crd $(oc get crd | grep istio.io | awk '{print $1}')
-oc delete clusterrole $(oc get clusterroles | grep istio)
-oc delete clusterrolebinding $(oc get clusterrolebinding | grep istio | awk '{print $1}'| grep ^istio)
-oc delete mutatingwebhookconfiguration istio-sidecar-injector 
-oc delete validatingwebhookconfigurations.admissionregistration.k8s.io istio-galley
-oc delete -n istio-operator installation istio-installation
+oc delete controlplane basic-install 
+```
+
+Verify that the controlplane custom resource is deleted and the operator has deleted the pods related to control plane in the `istio-system` project.
+
+```
+# oc get controlplane -n istio-system
+No resources found.
+
+# oc get po -n istio-system
+No resources found.
+```
+
+Note that istio-operator is still running. If you are interested in just removing control plane to reinstall, you can stop here.
+
+```
+# oc get po -n istio-operator
+NAME                              READY     STATUS    RESTARTS   AGE
+istio-operator-79c5b4d68f-b6gj2   1/1       Running   0          19h
+```
+
+If you want to remove istio-operator, run `oc delete` using the same template that we used to create the operator. This removes the CRDs and the deployment for the operator
+
+```
+# oc delete -n istio-operator -f https://raw.githubusercontent.com/Maistra/istio-operator/maistra-0.10/deploy/servicemesh-operator.yaml
+
+
+customresourcedefinition.apiextensions.k8s.io "installations.istio.openshift.com" deleted
+customresourcedefinition.apiextensions.k8s.io "controlplanes.istio.openshift.com" deleted
+clusterrole.rbac.authorization.k8s.io "istio-operator" deleted
+serviceaccount "istio-operator" deleted
+clusterrolebinding.rbac.authorization.k8s.io "istio-operator-account-istio-operator-cluster-role-binding" deleted
+deployment.apps "istio-operator" deleted
+```
+and delete respective projects
+
+```
+oc delete project istio-system
+```
+and
+
+```
 oc delete project istio-operator
-oc delete project istio-system  
 ```
+
+Now your cluster is completely free of istio and istio-operator.
+
 
 ## Preparing Istio Cluster for a Multi-user Workshop
-
-### Change OpenShift Router to handle Wildcard routes
-
-We'll configure OpenShift router to use Wildcard routes following the [documentation here](https://docs.openshift.com/container-platform/3.10/install_config/router/default_haproxy_router.html#using-wildcard-routes). This way we can expose a wildcard route for the `istio-ingressgateway` service. Once you have wildcard route for istio-ingressgateway, we can extend that route for each application to have a unique route.
-
-Run the following command to enable wildcard routes on the router in the `default` project
-
-```
-oc set env dc/router ROUTER_ALLOW_WILDCARD_ROUTES=true
-```
-The above command will edit the deployment configuration for the router and redeploy the router pods. Once the router pods are up and running, move forward.
-
-### Expose a Wildcard Route for Istio Ingress Gateway
-
-If you check the routes in the `istio-system` project, istio-installer should have already created an openshift route for the service `istio-ingressgateway`.
-
-```
-# oc get route istio-ingressgateway -n istio-system
-NAME                   HOST/PORT                                                    PATH      SERVICES               PORT      TERMINATION   WILDCARD
-istio-ingressgateway   istio-ingressgateway-istio-system.apps.devday.ocpcloud.com             istio-ingressgateway   http2                   None
-```
-This is a single entry point for all your application traffic running on Istio. If we want to run multiple applications we want to access them with different URLs.
-
-One way to accomplish that currently is to create a wildcard route for `istio-ingressgateway`. Since we enabled wildcard routes on our OpenShift cluster, let us expose a wildcard route for `istio-ingressgateway` service.
-
->**Note** substitute your own domain name for the `hostname` parameter. In my case `apps.devday.ocpcloud.com` is my openshift default domain. I have added `istio` to qualify all the istio applications. 
-
-```
-oc expose svc istio-ingressgateway --hostname="www.istio.apps.devday.ocpcloud.com" --port=http2 --name=istio-wildcard-ingress --wildcard-policy=Subdomain
-```
-
-
-This creates a route with the following configuration:
-
-```
-# oc get route istio-wildcard-ingress -o yaml -n istio-system
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  creationTimestamp: 2018-10-18T00:29:43Z
-  labels:
-    app: istio-ingressgateway
-    chart: gateways-1.0.1
-    heritage: Tiller
-    istio: ingressgateway
-    maistra-version: 0.2.0
-    release: istio-1.0.2
-  name: istio-wildcard-ingress
-  namespace: istio-system
-  resourceVersion: "4494685"
-  selfLink: /apis/route.openshift.io/v1/namespaces/istio-system/routes/istio-wildcard-ingress
-  uid: e89fc12a-d26c-11e8-900a-069c4762f7ea
-spec:
-  host: www.istio.apps.devday.ocpcloud.com
-  port:
-    targetPort: http2
-  to:
-    kind: Service
-    name: istio-ingressgateway
-    weight: 100
-  wildcardPolicy: Subdomain
-status:
-  ingress:
-  - conditions:
-    - lastTransitionTime: 2018-10-18T00:29:43Z
-      status: "True"
-      type: Admitted
-    host: www.istio.apps.devday.ocpcloud.com
-    routerName: router
-    wildcardPolicy: Subdomain
-```
-
-The `wildcardPolicy: Subdomain` in this configuration allows us to create specific hostnames for application such as `bookinfo1.istio.apps.devday.ocpcloud.com`, `bookinfo2.istio.apps.devday.ocpcloud.com` etc. **Of course, you will have your own domain names substituted in this example.**
-
-When we deploy an application later, we will learn how to configure application specific hostnames into the application gateway and virtualservice.
 
 ### Additional access to the users 
 
@@ -312,13 +288,13 @@ oc adm policy add-role-to-user view user1 -n istio-system
 ```
 > **Note** If you are enabling this cluster for a workshop with a bunch of users, run the above command for all the user-ids created for the workshop.
 
+
 ### Additional access to the project
 
 Applications are deployed in to projects/namespaces. On OpenShift the applications running in a namespace run with a `default` service account. This `default` service account runs with `restricted` SCC, which prevents it from running containers as specific user-ids or root, and also has restrictions on the linux capabilities. 
 
 Istio requires specific kinds of access at the project level:
 
-* Project needs to be labeled as `istio-injection=enabled` to let Istio know that this project can be used to enable automatic injection of side cars
 * As of now, the `default` service account need to be elevated to `privileged` SCC, so that it can allow the application pods to have init containers whose `proxy_init` runs in privileged mode and adds `NET_ADMIN`
 as shown here. You will find this configuration in the individual `deployment` artifacts when you deploy the application.
 
@@ -357,7 +333,6 @@ oc new-project bookinfo1
 oc adm policy add-scc-to-user privileged -z default -n bookinfo1
 oc adm policy add-scc-to-user anyuid -z default -n bookinfo1
 oc adm policy add-role-to-user admin user1 -n bookinfo1
-oc label namespace bookinfo1 istio-injection=enabled
 ```
 
 Now, if a user logs in as `user1`, they will see both `bookinfo1` and `istio-system` in their list.
@@ -369,7 +344,6 @@ In this chapter we learnt to perform the following administrative tasks on an Op
 
 * Preparing an OpenShift cluster to install Istio
 * Installed Istio
-* Set up Wildcard Router and a Wildcard route for istio-ingressgateway
 * Enabled user(s) to run applications on Istio
 * Created a project(s) with necessary privileges for end users to use 
 

--- a/RequestRouting.md
+++ b/RequestRouting.md
@@ -107,7 +107,7 @@ To generate some data that can be visualized by support services, you can access
 * Save the URL as an environment variable
 
 ```
-export URL=$(kubectl get route istio-ingressgateway -n istio-system -o yaml -o jsonpath={.spec.host})
+export URL=$(kubectl get virtualservice bookinfo -o yaml -o jsonpath={.spec.hosts[0]})
 ```
 
 * Invoke application in a loop


### PR DESCRIPTION
Openshift deployment using operator and IOR for routecreation instead of wildcard subdomain
Deploying app now uses annotation. No need for label on the project.